### PR TITLE
Fix typos in the README

### DIFF
--- a/README.md
+++ b/README.md
@@ -61,11 +61,11 @@ You should now be able to use Vanilla as normal.
      ```
    - On 64-bit systems:
      ```
-     sudo dpkg --add-architecture armhf
-     sudo apt-get update
-     sudo apt-get install libc6:armhf libisl23:armhf libmpfr6:armhf libmpc3:armhf libstdc++6:armhf
-     sudo ln -s /usr/lib/arm-linux-gnueabihf/libisl.so.23.*  /usr/lib/arm-linux-gnueabihf/libisl.so.10
-     sudo ln -s /usr/lib/arm-linux-gnueabihf/libmpfr.so.6.* /usr/lib/arm-linux-gnueabihf/libmpfr.so.4
+     dpkg --add-architecture armhf
+     apt-get update
+     apt-get install libc6:armhf libisl23:armhf libmpfr6:armhf libmpc3:armhf libstdc++6:armhf
+     ln -s /usr/lib/arm-linux-gnueabihf/libisl.so.23  /usr/lib/arm-linux-gnueabihf/libisl.so.10
+     ln -s /usr/lib/arm-linux-gnueabihf/libmpfr.so.6 /usr/lib/arm-linux-gnueabihf/libmpfr.so.4
      ```
 
 1. Clone the repository and enter it:


### PR DESCRIPTION
Running sudo while under su is redundant, and that glob with ln is wrong as far as I can tell